### PR TITLE
16: Get events only from selected calendars

### DIFF
--- a/app/src/main/java/com/mateuszholik/calendarapp/ui/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/mateuszholik/calendarapp/ui/calendar/CalendarScreen.kt
@@ -50,7 +50,9 @@ import com.mateuszholik.calendarapp.ui.calendar.CalendarViewModel.CalendarUserAc
 import com.mateuszholik.calendarapp.ui.calendar.CalendarViewModel.CalendarUserAction.EventClicked
 import com.mateuszholik.calendarapp.ui.calendar.CalendarViewModel.CalendarUserAction.SelectedDateChanged
 import com.mateuszholik.calendarapp.ui.calendar.CalendarViewModel.CalendarUserAction.ProfileClicked
+import com.mateuszholik.calendarapp.ui.calendar.CalendarViewModel.CalendarUserAction.RefreshScreen
 import com.mateuszholik.calendarapp.ui.observers.ObserveAsEvents
+import com.mateuszholik.calendarapp.ui.observers.ObserveResumeLifecycleState
 import com.mateuszholik.calendarapp.ui.utils.PreviewConstants.CURRENT_DATE
 import com.mateuszholik.calendarapp.ui.utils.PreviewConstants.DAYS_WITH_EVENTS
 import com.mateuszholik.calendarapp.ui.utils.PreviewConstants.EVENTS
@@ -90,6 +92,10 @@ fun CalendarScreen(
     val coroutineScope = rememberCoroutineScope()
 
     ChangeSystemBarColors(areIconsDark = isSystemInDarkTheme())
+
+    ObserveResumeLifecycleState {
+        viewModel.performUserAction(RefreshScreen)
+    }
 
     ObserveAsEvents(viewModel.uiEvent) { event ->
         when (event) {

--- a/app/src/main/java/com/mateuszholik/calendarapp/ui/observers/ObserveResumeLifecycleState.kt
+++ b/app/src/main/java/com/mateuszholik/calendarapp/ui/observers/ObserveResumeLifecycleState.kt
@@ -1,0 +1,18 @@
+package com.mateuszholik.calendarapp.ui.observers
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
+
+@Composable
+fun ObserveResumeLifecycleState(doOnResume: () -> Unit) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(lifecycleOwner.lifecycle) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            doOnResume()
+        }
+    }
+}

--- a/app/src/test/java/com/mateuszholik/calendarapp/ui/calendar/CalendarViewModelTest.kt
+++ b/app/src/test/java/com/mateuszholik/calendarapp/ui/calendar/CalendarViewModelTest.kt
@@ -60,8 +60,18 @@ internal class CalendarViewModelTest {
     }
 
     @Test
-    fun `After creating CalendarViewModel uiState initial values are set to CalendarInfo`() =
+    fun `After creating CalendarViewModel uiState initial value are set to Loading`() =
         runTest {
+            assertThat(viewModel.uiState.value).isEqualTo(
+                CalendarUiState.Loading
+            )
+        }
+
+    @Test
+    fun `After creating CalendarViewModel and calling RefreshScreen user action uiState value is equal to CalendarInfo`() =
+        runTest {
+            viewModel.performUserAction(CalendarUserAction.RefreshScreen)
+
             assertThat(viewModel.uiState.value).isEqualTo(
                 CalendarUiState.CalendarInfo(
                     currentDate = CURRENT_DATE,
@@ -79,6 +89,7 @@ internal class CalendarViewModelTest {
     @Test
     fun `When SelectedDateChanged user action is performed uiState emits new value`() =
         runTest {
+            viewModel.performUserAction(CalendarUserAction.RefreshScreen)
             coEvery { getEventsForDayUseCase(NEW_DATE) } returns EVENTS
 
             viewModel.performUserAction(CalendarUserAction.SelectedDateChanged(NEW_DATE))
@@ -98,6 +109,7 @@ internal class CalendarViewModelTest {
     @Test
     fun `When SelectedDateChanged user action is performed and error occurred then uiEvent emits Error value`() =
         runTest {
+            viewModel.performUserAction(CalendarUserAction.RefreshScreen)
             coEvery { getEventsForDayUseCase(NEW_DATE) } throws Exception("Something went wrong")
 
             viewModel.uiEvent.test {
@@ -114,6 +126,7 @@ internal class CalendarViewModelTest {
     @Test
     fun `When CurrentMonthChanged user action is performed uiState emits new value`() =
         runTest {
+            viewModel.performUserAction(CalendarUserAction.RefreshScreen)
             coEvery { getDaysWithEventsForMonthUseCase(NEW_MONTH) } returns DAYS_WITH_EVENTS
 
             viewModel.performUserAction(CalendarUserAction.CurrentMonthChanged(NEW_MONTH))
@@ -133,6 +146,7 @@ internal class CalendarViewModelTest {
     @Test
     fun `When CurrentMonthChanged user action is performed and error occurred then uiEvent emits Error value`() =
         runTest {
+            viewModel.performUserAction(CalendarUserAction.RefreshScreen)
             coEvery { getDaysWithEventsForMonthUseCase(NEW_MONTH) } throws Exception("Something went wrong")
 
             viewModel.uiEvent.test {

--- a/data/src/main/java/com/mateuszholik/data/di/MappersModule.kt
+++ b/data/src/main/java/com/mateuszholik/data/di/MappersModule.kt
@@ -1,5 +1,7 @@
 package com.mateuszholik.data.di
 
+import com.mateuszholik.data.mappers.CursorToCalendarIdsMapper
+import com.mateuszholik.data.mappers.CursorToCalendarIdsMapperImpl
 import com.mateuszholik.data.mappers.CursorToCalendarsMapper
 import com.mateuszholik.data.mappers.CursorToCalendarsMapperImpl
 import com.mateuszholik.data.mappers.CursorToEventsMapper
@@ -25,12 +27,18 @@ internal abstract class MappersModule {
     @Singleton
     @Binds
     abstract fun bindsCursorToListOfDaysMapper(
-        cursorToListOfDaysMapperImpl: CursorToListOfDaysMapperImpl
+        cursorToListOfDaysMapperImpl: CursorToListOfDaysMapperImpl,
     ): CursorToListOfDaysMapper
 
     @Singleton
     @Binds
     abstract fun bindsCursorToCalendarMapper(
-        cursorToCalendarsMapperImpl: CursorToCalendarsMapperImpl
+        cursorToCalendarsMapperImpl: CursorToCalendarsMapperImpl,
     ): CursorToCalendarsMapper
+
+    @Singleton
+    @Binds
+    abstract fun bindsCursorToCalendarIdsMapper(
+        cursorToCalendarIdsMapperImpl: CursorToCalendarIdsMapperImpl,
+    ): CursorToCalendarIdsMapper
 }

--- a/data/src/main/java/com/mateuszholik/data/factories/CalendarContentProviderQueryFactory.kt
+++ b/data/src/main/java/com/mateuszholik/data/factories/CalendarContentProviderQueryFactory.kt
@@ -11,6 +11,8 @@ internal interface CalendarContentProviderQueryFactory {
 
     suspend fun createForCalendars(): QueryData
 
+    suspend fun createForSelectedCalendarsIds(): QueryData
+
     suspend fun createForUpdateCalendarVisibility(
         calendarId: Long,
         isVisible: Boolean,
@@ -42,6 +44,14 @@ internal class CalendarContentProviderQueryFactoryImpl @Inject constructor() :
             selectionArgs = null
         )
     }
+
+    override suspend fun createForSelectedCalendarsIds(): QueryData =
+        QueryData(
+            uri = CalendarContract.Calendars.CONTENT_URI,
+            projection = arrayOf(CalendarContract.Calendars._ID),
+            selection = "(${CalendarContract.Calendars.VISIBLE} = 1)",
+            selectionArgs = null
+        )
 
     override suspend fun createForUpdateCalendarVisibility(
         calendarId: Long,

--- a/data/src/main/java/com/mateuszholik/data/mappers/CursorToCalendarIdsMapper.kt
+++ b/data/src/main/java/com/mateuszholik/data/mappers/CursorToCalendarIdsMapper.kt
@@ -1,0 +1,17 @@
+package com.mateuszholik.data.mappers
+
+import android.database.Cursor
+import com.mateuszholik.data.factories.CalendarContentProviderQueryFactory.Companion.CALENDAR_ID_INDEX
+import com.mateuszholik.data.mappers.base.Mapper
+import javax.inject.Inject
+
+internal interface CursorToCalendarIdsMapper : Mapper<Cursor, List<Long>>
+
+internal class CursorToCalendarIdsMapperImpl @Inject constructor() : CursorToCalendarIdsMapper {
+
+    override suspend fun map(param: Cursor): List<Long> =
+        List(param.count) {
+            param.moveToPosition(it)
+            param.getLong(CALENDAR_ID_INDEX)
+        }
+}


### PR DESCRIPTION
Changes made:

- Getting events only from selected calendars
- Added RefreshScreen UserAction in calendar screen
- Calling RefreshScreen UserAction on Lifecycle State RESUMED